### PR TITLE
:sparkles: Adds TakeWhilePeek

### DIFF
--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "7.83 kB",
-    "raw": 7832
+    "pretty": "7.93 kB",
+    "raw": 7934
   },
   "brotli": {
-    "pretty": "2.36 kB",
-    "raw": 2359
+    "pretty": "2.39 kB",
+    "raw": 2394
   }
 }

--- a/src/iterators/Peekable/takeWhilePeek.ts
+++ b/src/iterators/Peekable/takeWhilePeek.ts
@@ -1,0 +1,8 @@
+import type { PeekableRustIterator } from '../RustIterator.js';
+
+export function* takeWhilePeek<T>(
+  peekable: PeekableRustIterator<T>,
+  predicate: (value: T) => boolean,
+): Generator<T> {
+  while (predicate(peekable.peek().value)) yield peekable.next().value;
+}

--- a/src/iterators/RustIterator.ts
+++ b/src/iterators/RustIterator.ts
@@ -1,3 +1,4 @@
+import { takeWhilePeek } from './Peekable/takeWhilePeek.js';
 import { arrayChunks, size } from './arrayChunks.js';
 import { chain } from './chain.js';
 import { cycle } from './cycle.js';
@@ -244,5 +245,8 @@ export class PeekableRustIterator<T> extends RustIterator<T> {
   }
   peekable(): PeekableRustIterator<T> {
     return this;
+  }
+  takeWhilePeek(f: (val: T) => boolean): RustIterator<T> {
+    return new RustIterator(takeWhilePeek(this, f));
   }
 }

--- a/src/iterators/index.ts
+++ b/src/iterators/index.ts
@@ -18,4 +18,5 @@ export { window } from './window.js';
 export { zip } from './zip.js';
 export { r, range } from './range.js';
 export { RustIterator, PeekableRustIterator } from './RustIterator.js';
+export { takeWhilePeek } from './Peekable/takeWhilePeek.js';
 export default RustIterator;

--- a/test/iterators/Peekable/takeWhilePeek.test.ts
+++ b/test/iterators/Peekable/takeWhilePeek.test.ts
@@ -1,0 +1,11 @@
+import { PeekableRustIterator } from '@/iterators';
+
+describe('takeWhilePeek', () => {
+  it('should take while next passes predicate', () => {
+    const peekable = new PeekableRustIterator([1, 2, 3, 4, 5]);
+    const result = [...peekable.takeWhilePeek((val) => val < 4)];
+    expect(result).toEqual([1, 2, 3]);
+    expect(peekable.peek().value).toBe(4);
+    expect(peekable.next().value).toBe(4);
+  });
+});


### PR DESCRIPTION
Adds `takeWhilePeek` on `PeekableRustIterator`, which matches the behavior of `takeWhile` but does not consume the next value from the `PeekableRustIterator`, allowing `next` to be called on the underlying `PeekableRustIterator` to get the first value that fails the predicate after consuming the returned iterator.