### PR TITLE
:bug: Fixes issues with takeWhilePeek and ArrayChunks

### DIFF
--- a/size.json
+++ b/size.json
@@ -1,10 +1,10 @@
 {
   "minified": {
-    "pretty": "7.93 kB",
-    "raw": 7934
+    "pretty": "7.95 kB",
+    "raw": 7950
   },
   "brotli": {
     "pretty": "2.4 kB",
-    "raw": 2396
+    "raw": 2402
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export {
   arrayChunks,
-  size,
   chain,
   cycle,
   enumerate,

--- a/src/iterators/Peekable/takeWhilePeek.ts
+++ b/src/iterators/Peekable/takeWhilePeek.ts
@@ -4,5 +4,6 @@ export function* takeWhilePeek<T>(
   peekable: PeekableRustIterator<T>,
   predicate: (value: T) => boolean,
 ): Generator<T> {
-  while (predicate(peekable.peek().value)) yield peekable.next().value
+  while (!peekable.peek().done && predicate(peekable.peek().value))
+    yield peekable.next().value
 }

--- a/src/iterators/RustIterator.ts
+++ b/src/iterators/RustIterator.ts
@@ -1,5 +1,5 @@
 import { takeWhilePeek } from './Peekable/takeWhilePeek.js'
-import { arrayChunks, size } from './arrayChunks.js'
+import { arrayChunks } from './arrayChunks.js'
 import { chain } from './chain.js'
 import { cycle } from './cycle.js'
 import { enumerate } from './enumerate.js'
@@ -107,7 +107,7 @@ export class RustIterator<T> implements IterableIterator<T> {
     return [...this]
   }
 
-  arrayChunks<N extends size = 1>(size: N) {
+  arrayChunks<N extends number>(size: N) {
     return new RustIterator(arrayChunks<T, N>(this, size))
   }
 
@@ -165,7 +165,7 @@ export class RustIterator<T> implements IterableIterator<T> {
     return new RustIterator(flatMap(this, mapper))
   }
 
-  window<S extends size = 1>(n: S) {
+  window<S extends number>(n: S) {
     return new RustIterator(window<T, S>(this, n))
   }
 

--- a/src/iterators/arrayChunks.ts
+++ b/src/iterators/arrayChunks.ts
@@ -1,6 +1,4 @@
-import { Dec } from '../types/utils'
-
-export function* arrayChunks<T, N extends size = 1>(
+export function* arrayChunks<T, N extends number>(
   iter: Iterable<T>,
   size?: N,
 ): Generator<ChunkedArray<T, N>, void, undefined> {
@@ -15,7 +13,6 @@ export function* arrayChunks<T, N extends size = 1>(
   if (chunk.length) yield chunk as ChunkedArray<T, N>
 }
 
-export type size = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
-export type ChunkedArray<T, N extends size = 1> = N extends 0
-  ? []
-  : [T, ...ChunkedArray<T, Dec[N]>]
+export type ChunkedArray<T, N extends number> =
+  | (Array<T> & { length: N })
+  | never

--- a/src/iterators/index.ts
+++ b/src/iterators/index.ts
@@ -1,6 +1,6 @@
 import { RustIterator } from './RustIterator.js'
 
-export { arrayChunks, size } from './arrayChunks.js'
+export { arrayChunks } from './arrayChunks.js'
 export { chain } from './chain.js'
 export { cycle } from './cycle.js'
 export { enumerate } from './enumerate.js'

--- a/src/iterators/window.ts
+++ b/src/iterators/window.ts
@@ -1,6 +1,6 @@
-import { ChunkedArray, size } from './arrayChunks'
+import { ChunkedArray } from './arrayChunks'
 
-export function* window<T, S extends size = 1>(iter: Iterable<T>, size: S) {
+export function* window<T, S extends number>(iter: Iterable<T>, size: S) {
   let buffer: T[] = []
   for (const x of iter) {
     if (buffer.length === size) buffer = buffer.slice(1)


### PR DESCRIPTION
ArrayChunks and Window had difficult types that would always max out TS recursion. The new ones also don't work super well, but at least don't recurse infinitely.

takeWhilePeek would fail if the iterator would finish before a matching element was found